### PR TITLE
Remove hyphens in YAML key names for docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
           gateway: 172.20.0.1
 
 services:
-  sd-webhook:
+  sd_webhook:
     build: .
     image: sd-webhook
     ports:


### PR DESCRIPTION
Some YAML parsers get confused by indicator characters inside key names: the underscore is generally safe to use. Either that, or remove the hyphens entirely (using e.g. camelCase).
I'd also avoid the symbols in https://yaml.org/spec/1.2/spec.html#id2772075